### PR TITLE
chmod error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,5 @@ RUN apt-get update -qqy \
   && npm install -g gulp \
   && chmod 777 -R $ANDROID_HOME \
   && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/* \
-  && chown -R jenkins:jenkins /home/jenkins
+  && rm -rf /tmp/*
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM t4skforce/jenkins-slave
 
-ENV UID=1000
-ENV GID=1000
+ENV UID 1000
+ENV GID 1000
 ENV KOTLIN_VERSION "v1.2.51"
 ENV KOTLIN_DOWNLOADURL "https://github.com/JetBrains/kotlin/releases/download/v1.2.51/kotlin-compiler-1.2.51.zip"
 ENV ANDROID_SDK_VERSION "4333796"
@@ -47,7 +47,7 @@ RUN apt-get update -qqy \
   && chmod 777 -R $ANDROID_HOME \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/* \
-  && groupmod -g $GID jenkins \
-  && usermod -u $UID -g $GID jenkins \
+  && groupmod -g ${GID} jenkins \
+  && usermod -u ${UID} -g ${GID} jenkins \
   && chown -R jenkins:jenkins /home/jenkins 2> /dev/null; if [ $? -ne 0 ]; then echo "cannot chown directory"; fi
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM t4skforce/jenkins-slave
 
-ENV UID 1000
-ENV GID 1000
 ENV KOTLIN_VERSION "v1.2.51"
 ENV KOTLIN_DOWNLOADURL "https://github.com/JetBrains/kotlin/releases/download/v1.2.51/kotlin-compiler-1.2.51.zip"
 ENV ANDROID_SDK_VERSION "4333796"
@@ -47,7 +45,5 @@ RUN apt-get update -qqy \
   && chmod 777 -R $ANDROID_HOME \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/* \
-  && groupmod -g ${GID} jenkins \
-  && usermod -u ${UID} -g ${GID} jenkins \
   && chown -R jenkins:jenkins /home/jenkins 2> /dev/null; if [ $? -ne 0 ]; then echo "cannot chown directory"; fi
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM t4skforce/jenkins-slave
 
+ENV UID=1000
+ENV GID=1000
 ENV KOTLIN_VERSION "v1.2.51"
 ENV KOTLIN_DOWNLOADURL "https://github.com/JetBrains/kotlin/releases/download/v1.2.51/kotlin-compiler-1.2.51.zip"
 ENV ANDROID_SDK_VERSION "4333796"
@@ -44,5 +46,8 @@ RUN apt-get update -qqy \
   && npm install -g gulp \
   && chmod 777 -R $ANDROID_HOME \
   && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/*
+  && rm -rf /tmp/* \
+  && groupmod -g $GID jenkins \
+  && usermod -u $UID -g $GID jenkins \
+  && chown -R jenkins:jenkins /home/jenkins 2> /dev/null; if [ $? -ne 0 ]; then echo "cannot chown directory"; fi
 USER jenkins


### PR DESCRIPTION
let chown fail silently (or just with this echo). E.g. if you have your directory mounted via NFS and squashing the directory permitting any user changes.